### PR TITLE
Implement configurable DNS resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ This guide now specifically refers to the Gatesentry software and uses the `gate
 
 ### DNS Information
 
-Gatesentry ships with a built in DNS server, which can be used to block domains. The server as of now forwards requests to Google DNS for resolution, this can be modified from inside the `application/dns/server/server.go` file. 
+Gatesentry ships with a built in DNS server which can be used to block domains.  
+The resolver used for forwarding requests can now be configured via the
+application settings ("dns_resolver"). It defaults to Google DNS
+(`8.8.8.8:53`).
 
 ## Local Development
 

--- a/application/dns/server/server.go
+++ b/application/dns/server/server.go
@@ -38,6 +38,12 @@ var (
 	logger           *gatesentryLogger.Log
 )
 
+func SetExternalResolver(resolver string) {
+	if resolver != "" {
+		externalResolver = resolver
+	}
+}
+
 var server *dns.Server
 var serverRunning bool = false
 var restartDnsSchedulerChan chan bool
@@ -54,6 +60,7 @@ func StartDNSServer(basePath string, ilogger *gatesentryLogger.Log, blockedLists
 
 	logger = ilogger
 	logsPath = basePath + logsPath
+	SetExternalResolver(settings.Get("dns_resolver"))
 	go gatesentryDnsHttpServer.StartHTTPServer()
 	// InitializeLogs()
 	// go gatesentryDnsFilter.InitializeBlockedDomains(&blockedDomains, &blockedLists)

--- a/application/runtime.go
+++ b/application/runtime.go
@@ -176,6 +176,7 @@ func (R *GSRuntime) Init() {
 	R.GSSettings.SetDefault("timezone", "Europe/Oslo")
 	R.GSSettings.SetDefault("enable_https_filtering", "false")
 	R.GSSettings.SetDefault("enable_dns_server", "true")
+	R.GSSettings.SetDefault("dns_resolver", "8.8.8.8:53")
 	R.GSSettings.SetDefault("idemail", "")
 	R.GSSettings.SetDefault("enable_ai_image_filtering", "false")
 	R.GSSettings.SetDefault("ai_scanner_url", "")

--- a/application/webserver/endpoints/handler_settings.go
+++ b/application/webserver/endpoints/handler_settings.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	gatesentryDnsServer "bitbucket.org/abdullah_irfan/gatesentryf/dns/server"
 	gatesentry2storage "bitbucket.org/abdullah_irfan/gatesentryf/storage"
 	gatesentryWebserverTypes "bitbucket.org/abdullah_irfan/gatesentryf/webserver/types"
 	"github.com/badoux/checkmail"
@@ -24,7 +25,7 @@ func GSApiSettingsGET(requestedId string, settings *gatesentry2storage.MapStore)
 			value = string(valueJson)
 		}
 		return struct{ Value string }{Value: value}
-	case "blocktimes", "strictness", "timezone", "idemail", "enable_https_filtering", "capem", "keypem", "enable_dns_server", "dns_custom_entries", "ai_scanner_url", "enable_ai_image_filtering", "EnableUsers":
+	case "blocktimes", "strictness", "timezone", "idemail", "enable_https_filtering", "capem", "keypem", "enable_dns_server", "dns_custom_entries", "ai_scanner_url", "enable_ai_image_filtering", "EnableUsers", "dns_resolver":
 		value := settings.Get(requestedId)
 		return struct {
 			Key   string
@@ -81,12 +82,16 @@ func GSApiSettingsPOST(requestedId string, settings *gatesentry2storage.MapStore
 		requestedId == "enable_dns_server" ||
 		requestedId == "enable_https_filtering" ||
 		requestedId == "enable_ai_image_filtering" ||
-		requestedId == "ai_scanner_url" || 
-		requestedId == "EnableUsers" || 
-		requestedId == "strictness" || 
-		requestedId == "capem" || 
-		requestedId == "keypem" {
+		requestedId == "ai_scanner_url" ||
+		requestedId == "EnableUsers" ||
+		requestedId == "strictness" ||
+		requestedId == "capem" ||
+		requestedId == "keypem" ||
+		requestedId == "dns_resolver" {
 		settings.Update(requestedId, temp.Value)
+		if requestedId == "dns_resolver" {
+			gatesentryDnsServer.SetExternalResolver(temp.Value)
+		}
 	}
 
 	// fmt.Println( temp );

--- a/ui/src/routes/dns/dns.svelte
+++ b/ui/src/routes/dns/dns.svelte
@@ -13,6 +13,7 @@
   import { store } from "../../store/apistore";
   import { set } from "lodash";
   import { Restart } from "carbon-icons-svelte";
+  import ConnectedSettingInput from "../../components/connectedSettingInput.svelte";
   let dnsInfo = null;
 
   const loadDnsInfo = async () => {
@@ -74,6 +75,14 @@
         </div>
       </div>
     {/if}
+    <br />
+    <ConnectedSettingInput
+      keyName="dns_resolver"
+      title={$_("DNS Resolver")}
+      labelText={$_("DNS Resolver")}
+      type="text"
+      helperText=""
+    />
     <br />
     <DnsArecords on:updatednsinfo={onUpdateDnsInfo} />
   </Column>


### PR DESCRIPTION
## Summary
- make DNS resolver configurable in backend and default to `8.8.8.8:53`
- expose new `dns_resolver` setting via API and UI
- allow updating resolver while server is running
- document DNS resolver configuration

## Testing
- `go test ./...` *(fails: connection resets and missing lsof)*

------
https://chatgpt.com/codex/tasks/task_b_686fb18591f08324b48d3abf5e0384b9