### PR TITLE
Implement WebSocket proxying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## v1.23.0 (17 May 2026)
+
+- WebSocket proxy support: ws:// connections now properly proxied via TCP tunnel
+- (was rejecting all WebSocket connections with "not supported" error)
+
+## v1.22.0 (17 May 2026)
+
+- Fixed static file serving: restored CSS/JS assets, added MIME types, fixed vite.svg path
+- Restored block page CSS and JS deleted by frontend rebuild
+
 ## v1.21.0 (17 May 2026)
 
 - Device discovery service: mDNS/Bonjour browser, passive DNS observation, RFC 2136 DDNS UPDATE support

--- a/gatesentryproxy/websocket.go
+++ b/gatesentryproxy/websocket.go
@@ -1,8 +1,60 @@
 package gatesentryproxy
 
-import "net/http"
+import (
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
 
 func HandleWebsocketConnection(r *http.Request, w http.ResponseWriter) {
-	http.Error(w, "Web sockets currently not supported", http.StatusBadRequest)
-	return
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "Hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+	clientConn, _, err := hj.Hijack()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	defer clientConn.Close()
+
+	upstreamAddr := r.URL.Host
+	if upstreamAddr == "" {
+		upstreamAddr = r.Host
+	}
+	if _, _, err := net.SplitHostPort(upstreamAddr); err != nil {
+		upstreamAddr = net.JoinHostPort(upstreamAddr, "80")
+	}
+
+	upstreamConn, err := net.DialTimeout("tcp", upstreamAddr, 10*time.Second)
+	if err != nil {
+		log.Printf("WebSocket proxy: dial %s: %v", upstreamAddr, err)
+		return
+	}
+	defer upstreamConn.Close()
+
+	r.RequestURI = r.URL.RequestURI()
+
+	if err := r.Write(upstreamConn); err != nil {
+		log.Printf("WebSocket proxy: write request to %s: %v", upstreamAddr, err)
+		return
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		io.Copy(upstreamConn, clientConn)
+		upstreamConn.Close()
+		wg.Done()
+	}()
+	go func() {
+		io.Copy(clientConn, upstreamConn)
+		clientConn.Close()
+		wg.Done()
+	}()
+	wg.Wait()
 }

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ var GSPROXYPORT = "10413"
 var GSWEBADMINPORT = "10786"
 var GSBASEDIR = ""
 var Baseendpointv2 = "https://www.gatesentryfilter.com/api/"
-var GATESENTRY_VERSION = "1.22.0"
+var GATESENTRY_VERSION = "1.23.0"
 var GS_BOUND_ADDRESS = ":"
 var R *application.GSRuntime
 


### PR DESCRIPTION
Replaces the WebSocket stub (which returned an error) with a proper TCP tunnel implementation.

```
gatesentryproxy/websocket.go```: Implement `HandleWebsocketConnection` to:
1. Hijack the client HTTP connection
2. Dial the upstream server via TCP
3. Forward the HTTP upgrade request in origin-form
4. Bridge bidirectional data between client and upstream (raw TCP tunnel)

The proxy already detected WebSocket upgrades at `proxy.go:383` and routed them to `HandleWebsocketConnection` — the function just returned an error. This change implements the actual proxying.

- **ws://** connections: handled by this implementation
- **wss://** connections: already worked via the existing CONNECT tunnel

Builds clean: `go build ./...` passes.